### PR TITLE
Fix whitespace in zappr configuration

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -1,9 +1,9 @@
 approvals:
-  groups:
-    zalando:
-      minimum: 2
-      from:
-        orgs:
-          - zalando
+  groups:
+    zalando:
+      minimum: 2
+      from:
+        orgs:
+          - zalando
 X-Zalando-Team: "aruha"
 X-Zalando-Type: code


### PR DESCRIPTION
Zappr config used `U+2000` instead of space characters for some reason.